### PR TITLE
Improve uniqueness of precedence group names

### DIFF
--- a/Sources/Compose.swift
+++ b/Sources/Compose.swift
@@ -1,9 +1,9 @@
-precedencegroup CompositionPrecedence {
+precedencegroup MozartCompositionPrecedence {
     associativity: right
     higherThan: BitwiseShiftPrecedence
 }
 
-infix operator • : CompositionPrecedence
+infix operator • : MozartCompositionPrecedence
 public func • <T, U, V>(f: @escaping (U) -> V, g: @escaping (T) -> U) -> (T) -> V {
   return compose(f, g)
 }

--- a/Sources/Pipe.swift
+++ b/Sources/Pipe.swift
@@ -1,9 +1,9 @@
-precedencegroup PipePrecedence {
+precedencegroup MozartPipePrecedence {
   associativity: left
   higherThan: DefaultPrecedence
 }
 
-infix operator |> : PipePrecedence
+infix operator |> : MozartPipePrecedence
 public func |> <T, U>(x: T, f: (T) -> U) -> U {
   return f(x)
 }


### PR DESCRIPTION
Turns out these need to be unique! Fun stuff. To reduce the likelyhood that
these will conflict with other predecencegroups in the future, we're going to
go ahead and prefix them with our package name.

Awful.
